### PR TITLE
fix: use PlayerDB to get skins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 				"eslint-plugin-json": "3.1.0",
 				"eslint-plugin-unicorn": "49.0.0",
 				"typescript": "5.2.2",
-				"wrangler": "3.15.0"
+				"wrangler": "3.24.0"
 			},
 			"engines": {
 				"node": ">= 18"
@@ -225,9 +225,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20231025.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20231025.0.tgz",
-			"integrity": "sha512-MYRYTbSl+tjGg6su7savlLIb8cOcKJfdGpA+WdtgqT2OF7O+89Lag0l1SA/iyVlUkT31Jc6OLHqvzsXgmg+niQ==",
+			"version": "1.20231218.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20231218.0.tgz",
+			"integrity": "sha512-547gOmTIVmRdDy7HNAGJUPELa+fSDm2Y0OCxqAtQOz0GLTDu1vX61xYmsb2rn91+v3xW6eMttEIpbYokKjtfJA==",
 			"cpu": [
 				"x64"
 			],
@@ -241,9 +241,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20231025.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20231025.0.tgz",
-			"integrity": "sha512-BszjtBDR84TVa6oWe74dePJSAukWlTmLw9zR4KeWuwZLJGV7RMm6AmwGStetjnwZrecZaaOFELfBCAHtsebV0Q==",
+			"version": "1.20231218.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20231218.0.tgz",
+			"integrity": "sha512-b39qrU1bKolCfmKFDAnX4vXcqzISkEUVE/V8sMBsFzxrIpNAbcUHBZAQPYmS/OHIGB94KjOVokvDi7J6UNurPw==",
 			"cpu": [
 				"arm64"
 			],
@@ -257,9 +257,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20231025.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20231025.0.tgz",
-			"integrity": "sha512-AT9dxgKXOa9xZxZ3k2a432axPJJ58KpoNWnPiPYGpuAuLoWnfcYwwh6mr9sZVcTdAdTAK9Xu9c81tp0YABanUw==",
+			"version": "1.20231218.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20231218.0.tgz",
+			"integrity": "sha512-dMUF1wA+0mybm6hHNOCgY/WMNMwomPPs4I7vvYCgwHSkch0Q2Wb7TnxQZSt8d1PK/myibaBwadrlIxpjxmpz3w==",
 			"cpu": [
 				"x64"
 			],
@@ -273,9 +273,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20231025.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20231025.0.tgz",
-			"integrity": "sha512-EIjex5o2k80YZWPix1btGybL/vNZ3o6vqKX9ptS0JcFkHV5aFX5/kcMwSBRjiIC+w04zVjmGQx3N1Vh3njuncg==",
+			"version": "1.20231218.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20231218.0.tgz",
+			"integrity": "sha512-2s5uc8IHt0QmWyKxAr1Fy+4b8Xy0b/oUtlPnm5MrKi2gDRlZzR7JvxENPJCpCnYENydS8lzvkMiAFECPBccmyQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -289,9 +289,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20231025.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20231025.0.tgz",
-			"integrity": "sha512-7vtq0mO22A2v0OOsKXa760r9a84Gg8CK0gDu5uNWlj6hojmt011iz7jJt76I7oo/XrVwVlVfu69GnA3ljx6U8w==",
+			"version": "1.20231218.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20231218.0.tgz",
+			"integrity": "sha512-oN5hz6TXUDB5YKUN5N3QWAv6cYz9JjTZ9g16HVyoegVFEL6/zXU3tV19MBX2IvlE11ab/mRogEv9KXVIrHfKmA==",
 			"cpu": [
 				"x64"
 			],
@@ -309,6 +309,18 @@
 			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20231025.0.tgz",
 			"integrity": "sha512-TkcZkntUTOcvJ4vgmwpNfLTclpMbmbClZCe62B25/VTukmyv91joRa4eKzSjzCZUXTbFHNmVdOpmGaaJU2U3+A==",
 			"dev": true
+		},
+		"node_modules/@cspotcode/source-map-support": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/trace-mapping": "0.3.9"
+			},
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/@esbuild-plugins/node-globals-polyfill": {
 			"version": "0.2.3",
@@ -782,6 +794,31 @@
 			"integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
 			"dev": true
 		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+			"integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.4.15",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+			"dev": true
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
 		"node_modules/@nodecraft/eslint-config": {
 			"version": "30.0.0",
 			"resolved": "https://registry.npmjs.org/@nodecraft/eslint-config/-/eslint-config-30.0.0.tgz",
@@ -1177,9 +1214,9 @@
 			}
 		},
 		"node_modules/acorn-walk": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.0.tgz",
-			"integrity": "sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==",
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+			"integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.4.0"
@@ -1459,12 +1496,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/buffer-from": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-			"dev": true
 		},
 		"node_modules/builtin-modules": {
 			"version": "3.3.0",
@@ -3285,23 +3316,26 @@
 			}
 		},
 		"node_modules/miniflare": {
-			"version": "3.20231025.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20231025.0.tgz",
-			"integrity": "sha512-pFcr2BRaGIQ26UfdDo8BMJ6kkd/Jo/FkQ/4K7UG/eORlDepsLrR/sTJddcSSIGl07MA+MGjhzopFTPpFskkS+g==",
+			"version": "3.20231218.3",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20231218.3.tgz",
+			"integrity": "sha512-OrPBYWO0WnFv6DrxZ7hF8f5agZ4+xo/2qSLE0wwCJSqlFhr91dfSJautxfCOBD896nAA7Jqr5LBPEnqq3/k/JQ==",
 			"dev": true,
 			"dependencies": {
+				"@cspotcode/source-map-support": "0.8.1",
 				"acorn": "^8.8.0",
 				"acorn-walk": "^8.2.0",
 				"capnp-ts": "^0.7.0",
 				"exit-hook": "^2.2.1",
 				"glob-to-regexp": "^0.4.1",
-				"source-map-support": "0.5.21",
 				"stoppable": "^1.1.0",
-				"undici": "^5.22.1",
-				"workerd": "1.20231025.0",
+				"undici": "^5.28.2",
+				"workerd": "1.20231218.0",
 				"ws": "^8.11.0",
 				"youch": "^3.2.2",
 				"zod": "^3.20.6"
+			},
+			"bin": {
+				"miniflare": "bootstrap.js"
 			},
 			"engines": {
 				"node": ">=16.13"
@@ -4137,16 +4171,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/source-map-support": {
-			"version": "0.5.21",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-			"dev": true,
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
-			}
-		},
 		"node_modules/sourcemap-codec": {
 			"version": "1.4.8",
 			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
@@ -4486,9 +4510,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "5.27.2",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.27.2.tgz",
-			"integrity": "sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==",
+			"version": "5.28.2",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
+			"integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
 			"dev": true,
 			"dependencies": {
 				"@fastify/busboy": "^2.0.0"
@@ -4610,9 +4634,9 @@
 			}
 		},
 		"node_modules/workerd": {
-			"version": "1.20231025.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20231025.0.tgz",
-			"integrity": "sha512-W1PFtpMFfvmm+ozBf+u70TE3Pviv7WA4qzDeejHDC4z+PFDq4+3KJCkgffaGBO86h+akWO0hSsc0uXL2zAqofQ==",
+			"version": "1.20231218.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20231218.0.tgz",
+			"integrity": "sha512-AGIsDvqCrcwhoA9kb1hxOhVAe53/xJeaGZxL4FbYI9FvO17DZwrnqGq+6eqItJ6Cfw1ZLmf3BM+QdMWaL2bFWQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -4622,17 +4646,17 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20231025.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20231025.0",
-				"@cloudflare/workerd-linux-64": "1.20231025.0",
-				"@cloudflare/workerd-linux-arm64": "1.20231025.0",
-				"@cloudflare/workerd-windows-64": "1.20231025.0"
+				"@cloudflare/workerd-darwin-64": "1.20231218.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20231218.0",
+				"@cloudflare/workerd-linux-64": "1.20231218.0",
+				"@cloudflare/workerd-linux-arm64": "1.20231218.0",
+				"@cloudflare/workerd-windows-64": "1.20231218.0"
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "3.15.0",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.15.0.tgz",
-			"integrity": "sha512-kxzK62rD+LRrDeZZzw8cP6FBub71vJCbfAAb594XobXajgXYh3pFjv18Vm8YLxHzoGMhmAOJPA5b4DHq4HEUCw==",
+			"version": "3.24.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.24.0.tgz",
+			"integrity": "sha512-jEnqpY+9/J4VPjtuEnS2lhCPXkvbDClnMalSWaRxSx+1tiTWMJhMjtK9oyXLdO+ZUf9Q4LvFTYSPm8O1uwmnxQ==",
 			"dev": true,
 			"dependencies": {
 				"@cloudflare/kv-asset-handler": "^0.2.0",
@@ -4641,13 +4665,13 @@
 				"blake3-wasm": "^2.1.5",
 				"chokidar": "^3.5.3",
 				"esbuild": "0.17.19",
-				"miniflare": "3.20231025.0",
+				"miniflare": "3.20231218.3",
 				"nanoid": "^3.3.3",
 				"path-to-regexp": "^6.2.0",
+				"resolve": "^1.22.8",
 				"resolve.exports": "^2.0.2",
 				"selfsigned": "^2.0.1",
 				"source-map": "0.6.1",
-				"source-map-support": "0.5.21",
 				"xxhash-wasm": "^1.0.1"
 			},
 			"bin": {
@@ -4677,9 +4701,9 @@
 			"dev": true
 		},
 		"node_modules/ws": {
-			"version": "8.14.2",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-			"integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+			"integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	"scripts": {
 		"check-types": "npm run check-types:server",
 		"check-types:server": "tsc --noemit",
-		"dev": "wrangler dev --remote",
+		"dev": "wrangler dev",
 		"lint": "npm run lint:js && npm run check-types",
 		"lint:js": "eslint \"**/*.{js,mjs,cjs,ts}\" \"**/*.json\"",
 		"lint:js:fix": "npm run lint:js -- --fix",
@@ -29,7 +29,7 @@
 		"eslint-plugin-json": "3.1.0",
 		"eslint-plugin-unicorn": "49.0.0",
 		"typescript": "5.2.2",
-		"wrangler": "3.15.0"
+		"wrangler": "3.24.0"
 	},
 	"engines": {
 		"node": ">= 18"

--- a/worker/services/mojang/api.ts
+++ b/worker/services/mojang/api.ts
@@ -120,7 +120,7 @@ export class CachedMojangApiService implements MojangApiService {
 // Implements MojangApiService by contacting the Mojang API endpoints directly.
 export class DirectMojangApiService implements MojangApiService {
 	async lookupUsername(username: string, gatherer: PromiseGatherer | null): Promise<MojangUsernameLookupResult | null> {
-		const lookupResponse = await fetch(`https://api.mojang.com/users/profiles/minecraft/${username}`, {
+		const lookupResponse = await fetch(`https://playerdb.co/api/player/minecraft/${username}`, {
 			headers: {
 				'Content-Type': 'application/json',
 				'User-Agent': 'Crafthead (+https://crafthead.net)',
@@ -132,11 +132,18 @@ export class DirectMojangApiService implements MojangApiService {
 		} else if (!lookupResponse.ok) {
 			throw new Error('Unable to lookup UUID for username, http status ' + lookupResponse.status);
 		} else {
-			const contents: MojangUsernameLookupResult | undefined = await lookupResponse.json();
-			if (contents === undefined) {
+			const jsonData: PlayerDBProfile = await lookupResponse.json();
+			const returnedProfile = jsonData.data?.player;
+
+			// Now we need to mangle this data into the format we expect.
+			const data = {
+				id: returnedProfile.raw_id,
+				name: returnedProfile.username,
+			};
+			if (data === undefined) {
 				return null;
 			}
-			return contents;
+			return data;
 		}
 	}
 
@@ -157,7 +164,6 @@ export class DirectMojangApiService implements MojangApiService {
 				name: returnedProfile.username,
 				properties: returnedProfile.properties,
 			};
-			console.log(data);
 			return {
 				result: data,
 				source: 'miss',


### PR DESCRIPTION
This swaps from using Mojang's API directly to using PlayerDB to pull the skins. This'll resolve any issues with Mojang 403 or rate limiting. 

Closes #82 #68