### PR TITLE
fix: improve double clicking UX on URLs

### DIFF
--- a/website/index.css
+++ b/website/index.css
@@ -215,6 +215,14 @@ article h2#h2-404 {
 	image-rendering: pixelated;
 }
 
+.example code.verb {
+	flex-grow: 0;
+}
+
+.example code.url {
+	flex-grow: 1;
+}
+
 @media screen and (max-width: 600px) {
 	.example {
 		flex-direction: column-reverse;

--- a/website/index.html
+++ b/website/index.html
@@ -77,128 +77,111 @@
 
 			<h3>Fetch an avatar</h3>
 			<div class="example">
-				<code>
-					GET https://crafthead.net/avatar/ecfc3640f601406c9f9f1f857fc76f9d
-				</code>
+				<code class="verb">GET</code>
+				<code class="url">https://crafthead.net/avatar/ecfc3640f601406c9f9f1f857fc76f9d</code>
 				<img src="/avatar/ecfc3640f601406c9f9f1f857fc76f9d" class="render-pixelate" alt="Default example" width="32"
 					height="32">
 			</div>
 
 			<p>Need a different size?</p>
 			<div class="example">
-				<code>
-					GET https://crafthead.net/avatar/dcc4c006582b4f798f71654b477807c2/128
-				</code>
+				<code class="verb">GET</code>
+				<code class="url">https://crafthead.net/avatar/dcc4c006582b4f798f71654b477807c2/128</code>
 				<img src="/avatar/dcc4c006582b4f798f71654b477807c2/128" class="render-pixelate" alt="Default example"
 					width="128" height="128">
 			</div>
 
 			<p>Got a dashed UUID? We will remove the dashes for you.</p>
 			<div class="example">
-				<code>
-					GET https://crafthead.net/avatar/c6309b6b-8aac-4aab-8fef-a1e6853316ec
-				</code>
+				<code class="verb">GET</code>
+				<code class="url">https://crafthead.net/avatar/c6309b6b-8aac-4aab-8fef-a1e6853316ec</code>
 				<img src="/avatar/c6309b6b-8aac-4aab-8fef-a1e6853316ec" class="render-pixelate" alt="Default example"
 					width="32" height="32">
 			</div>
 
 			<p>We support usernames, too.</p>
 			<div class="example">
-				<code>
-					GET https://crafthead.net/avatar/LadyAgnes
-				</code>
+				<code class="verb">GET</code>
+				<code class="url">https://crafthead.net/avatar/LadyAgnes</code>
 				<img src="/avatar/LadyAgnes" class="render-pixelate" alt="Default example" width="32" height="32">
 			</div>
 
 			<p>Want a helm?</p>
 			<div class="example">
-				<code>
-					GET https://crafthead.net/helm/Reply
-				</code>
+				<code class="verb">GET</code>
+				<code class="url">https://crafthead.net/helm/Reply</code>
 				<img src="/helm/Reply" class="render-pixelate" alt="Default example" width="32" height="32">
 			</div>
 
 			<p>Cube heads go well with a cube game.</p>
 			<div class="example">
-				<code>
-					GET https://crafthead.net/cube/48a0a7e4d5594873a617dc189f76a8a1
-				</code>
+				<code class="verb">GET</code>
+				<code class="url">https://crafthead.net/cube/48a0a7e4d5594873a617dc189f76a8a1</code>
 				<img src="/cube/48a0a7e4d5594873a617dc189f76a8a1/32" alt="Default example" width="32">
 			</div>
 
 			<h3>Fetch a player's body</h3>
 			<div class="example">
-				<code>
-					GET https://crafthead.net/body/48a0a7e4d5594873a617dc189f76a8a1
-				</code>
+				<code class="verb">GET</code>
+				<code class="url">https://crafthead.net/body/48a0a7e4d5594873a617dc189f76a8a1</code>
 				<img src="/body/48a0a7e4d5594873a617dc189f76a8a1/32" class="render-pixelate" alt="Default example" width="32" height="64">
 			</div>
 			<div class="example">
-				<code>
-					GET https://crafthead.net/armor/body/Reply
-				</code>
+				<code class="verb">GET</code>
+				<code class="url">https://crafthead.net/armor/body/Reply</code>
 				<img src="/armor/body/Reply/32" class="render-pixelate" alt="Default example" width="32" height="64">
 			</div>
 
 			<h3>Fetch a player's bust</h3>
 			<div class="example">
-				<code>
-					GET https://crafthead.net/bust/6a085b2c19fb4986b453231aa942bbec
-				</code>
+				<code class="verb">GET</code>
+				<code class="url">https://crafthead.net/bust/6a085b2c19fb4986b453231aa942bbec</code>
 				<img src="/bust/6a085b2c19fb4986b453231aa942bbec/32" class="render-pixelate" alt="Default example" width="32" height="32">
 			</div>
 			<div class="example">
-				<code>
-					GET https://crafthead.net/armor/bust/Reply
-				</code>
+				<code class="verb">GET</code>
+				<code class="url">https://crafthead.net/armor/bust/Reply</code>
 				<img src="/armor/bust/Reply/32" class="render-pixelate" alt="Default example" width="32" height="32">
 			</div>
 
 			<h3>Fetch a player's skin</h3>
 			<div class="example">
-				<code>
-					GET https://crafthead.net/skin/652a2bc4e8cd405db7b698156ee2dc09
-				</code>
+				<code class="verb">GET</code>
+				<code class="url">https://crafthead.net/skin/652a2bc4e8cd405db7b698156ee2dc09</code>
 				<img src="/skin/652a2bc4e8cd405db7b698156ee2dc09" class="render-pixelate" alt="Default example" width="64"
 					height="64">
 			</div>
 			<div class="example">
-				<code>
-					GET https://crafthead.net/skin/Reply
-				</code>
+				<code class="verb">GET</code>
+				<code class="url">https://crafthead.net/skin/Reply</code>
 				<img src="/skin/Reply" class="render-pixelate" alt="Default example" width="64" height="32">
 			</div>
 			<div class="example">
-				<code>
-					GET https://crafthead.net/skin/char
-				</code>
+				<code class="verb">GET</code>
+				<code class="url">https://crafthead.net/skin/char</code>
 				<img src="/skin/char" class="render-pixelate" alt="Default example" width="64" height="32">
 			</div>
 
 			<h3>Fetch a player's cape</h3>
 			<div class="example">
-				<code>
-					GET https://crafthead.net/cape/1ccef50bf6ae4542b1a9d434384a5b25
-				</code>
+				<code class="verb">GET</code>
+				<code class="url">https://crafthead.net/cape/1ccef50bf6ae4542b1a9d434384a5b25</code>
 				<img src="/cape/1ccef50bf6ae4542b1a9d434384a5b25/32" class="render-pixelate" alt="Default example" width="20" height="32">
 			</div>
 			<div class="example">
-				<code>
-					GET https://crafthead.net/cape/LadyAgnes
-				</code>
+				<code class="verb">GET</code>
+				<code class="url">https://crafthead.net/cape/LadyAgnes</code>
 				<img src="/cape/LadyAgnes/32" class="render-pixelate" alt="Default example" width="20" height="32">
 			</div>
 
 			<h3>Fetch a player's profile</h3>
 			<div class="example">
-				<code>
-					GET https://crafthead.net/profile/652a2bc4e8cd405db7b698156ee2dc09
-				</code>
+				<code class="verb">GET</code>
+				<code class="url">https://crafthead.net/profile/652a2bc4e8cd405db7b698156ee2dc09</code>
 			</div>
 			<div class="example">
-				<code>
-					GET https://crafthead.net/profile/Reply
-				</code>
+				<code class="verb">GET</code>
+				<code class="url">https://crafthead.net/profile/Reply</code>
 			</div>
 		</div>
 	</article>


### PR DESCRIPTION
By splitting the HTTP verb and the URL into two separate `code` blocks, you can now double click on the URL without selecting the verb too, allowing for more easy copy/pasting.