### PR TITLE
feat: use service binding to playerdb for improved perf

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Then:
 * Copy `wrangler.toml.dev` to `wrangler.toml` and fill in your own `account_id`.
   in your configuration with the output from the command.
 * Use `npm ci` to install all the development dependencies
+* You may need to remove the `services` section from `wrangler.toml`
 * Use `wrangler publish`. You're done!
 
 ### Notes on `wrangler preview`

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -186,11 +186,11 @@ async function handleRequest(request: Request, env: Env, ctx: ExecutionContext) 
 		const hitCache = Boolean(response);
 		if (!response) {
 			// The item is not in the Cloudflare datacenter's cache. We need to process the request further.
-			console.log('Request not satisfied from cache.');
+			//console.log('Request not satisfied from cache.');
 
 			const gatherer = new PromiseGatherer();
 
-			const skinService = new MojangRequestService(new DirectMojangApiService());
+			const skinService = new MojangRequestService(new DirectMojangApiService(env));
 			response = await processRequest(skinService, interpreted, gatherer);
 			if (response.ok) {
 				const cacheResponse = response.clone();
@@ -216,6 +216,7 @@ async function handleRequest(request: Request, env: Env, ctx: ExecutionContext) 
 			identityType: interpreted.identityType,
 			responseCode: 500,
 		});
+		console.error('Error processing request', err);
 		return new Response((err as Error).toString(), { status: 500 });
 	}
 }

--- a/worker/services/mojang/service.ts
+++ b/worker/services/mojang/service.ts
@@ -165,12 +165,12 @@ export default class MojangRequestService {
 					throw new Error(`Unable to retrieve texture from Mojang, http status ${textureResponse.status}`);
 				}
 
-				console.log('Successfully retrieved texture');
+				//console.log('Successfully retrieved texture');
 				return { texture: textureResponse, model: texturesData?.SKIN?.metadata?.model };
 			}
 		}
 
-		console.log('Invalid properties found! Falling back to a default texture.');
+		//console.log('Invalid properties found! Falling back to a default texture.');
 		return undefined;
 	}
 
@@ -192,7 +192,6 @@ export default class MojangRequestService {
 
 		const rawJson = atob(property.value);
 		const decoded: MojangTexturePropertyValue = JSON.parse(rawJson);
-		console.log('Raw textures property: ', property);
 
 		return decoded.textures;
 	}

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -2,4 +2,5 @@ export interface Env {
 	__STATIC_CONTENT: KVNamespace;
 
 	CRAFTHEAD_ANALYTICS?: AnalyticsEngineDataset;
+	PLAYERDB?: Fetcher;
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -18,3 +18,6 @@ route = { pattern = "crafthead.net/*", zone_name = "crafthead.net" }
 analytics_engine_datasets = [
 	{ binding = "CRAFTHEAD_ANALYTICS" }
 ]
+services = [
+  { binding = "PLAYERDB", service = "playerdb" }
+]


### PR DESCRIPTION
By using a service binding, we can shave 10-15ms off every request needing to go through Cloudflare's network stack for `playerdb.co`. 

There's a fallback to just go over the public internet for self-hosting, or in local dev, etc.